### PR TITLE
fix: revert header to older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,11 +29,6 @@
     </button>
 
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
-
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -137,27 +137,6 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
-
 /* Main Content Area with Sidebar */
 .main-content {
     flex: 1;
@@ -866,15 +845,7 @@ details[open] .suggested-header::before {
     .chat-main {
         order: 1;
     }
-    
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
-    
+
     .chat-messages {
         padding: 1rem;
     }


### PR DESCRIPTION
Resolves #3

Reverted the header to the older version by removing the following elements:

- ✅ Removed "Course Materials Assistant" header
- ✅ Removed subtitle "Ask questions about courses, instructors, and content"
- ✅ Cleaned up unused header CSS styles
- ✅ Preserved theme toggle button functionality

### Changes

**frontend/index.html**
- Removed the entire `<header>` section

**frontend/style.css**
- Removed header styling rules
- Removed subtitle styling rules
- Removed responsive header styles

Generated with [Claude Code](https://claude.ai/code)